### PR TITLE
docs: rewrite profile for AI Infrastructure Builder narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,130 +1,76 @@
 # James C. Young
 
-**Forward Deployed Software Engineer | AI Enablement | Operational Intelligence**
+**AI Infrastructure Builder** — I build the systems that make AI agents work in production: orchestration runtimes, coordination protocols, budget controls, and resilience patterns.
 
-17 years in manufacturing operations. I now build automation, AI workflows, and operational systems to replace tribal knowledge and firefighting.
----
-
-## Portfolio — Operational Intelligence & AI Workflows
+17 years in manufacturing operations. Self-taught engineer. Now building production infrastructure for AI systems.
 
 ---
+
+## Pinned
 
 ### [Gorgon](https://github.com/AreteDriver/Gorgon)
-**Multi-agent AI orchestration framework**
+Production runtime for AI agent workflows. 10 specialized agents coordinate across pipelines with budget enforcement, automatic checkpoints, and circuit breakers. Every run is auditable and resumable.
 
-Coordinate specialized AI agents (Planner → Builder → Tester → Reviewer) across enterprise workflows. FastAPI backend, React dashboard, token/cost tracking. 85K+ LOC, 3600+ tests.
+**5,200+ tests** · Python · FastAPI · MIT
 
-![Gorgon Stack](https://img.shields.io/badge/Stack-FastAPI%20|%20Claude%20|%20React-purple)
+### [Convergent](https://github.com/AreteDriver/convergent)
+Coordination library for multi-agent systems. Agents share an intent graph, detect overlaps before building, and converge on compatible outputs — eliminating rework from parallel code generation. Zero dependencies, optional Rust acceleration.
 
-**Demonstrates:** AI workflow design, production instrumentation, agent coordination
+**670+ tests · 97% coverage** · Python · PyO3 · MIT
 
----
+### [RedOPS](https://github.com/AreteDriver/RedOPS)
+Offensive security operations platform. Recon, scanning, vulnerability analysis, and reporting — orchestrated through structured pipelines with full audit trails.
 
-### [Animus](https://github.com/AreteDriver/animus)
-**Personal AI exocortex framework**
-
-Local-first memory system with vector storage, multi-model reasoning, and self-learning with guardrails. 18K LOC, 333 tests.
-
-![Animus Stack](https://img.shields.io/badge/Stack-Python%20|%20ChromaDB%20|%20FastAPI-teal)
-
-**Demonstrates:** AI memory architecture, safety guardrails, local-first design
+**5,000+ tests** · Python · MIT
 
 ---
 
-### [Argus Overview](https://github.com/AreteDriver/Argus_Overview)
-**Professional multi-boxing tool for EVE Online (Linux)**
+## Now
 
-Real-time 30 FPS window previews, team management, auto-tiling layouts, EVE settings sync. 2,500+ downloads.
+Building coordination infrastructure for parallel AI code generation. Current focus: distributed signal bus for cross-process agent coordination (Convergent v0.6.0).
 
-![Argus Stack](https://img.shields.io/badge/Stack-Python%20|%20PySide6%20|%20X11-green)
+## Proof
 
-**Demonstrates:** Desktop application development, performance optimization, user-facing tools
-
----
-
-### [EVE Rebellion](https://github.com/AreteDriver/eve_rebellion_rust)
-**Top-down arcade shooter in the EVE Online universe**
-
-Rust/Bevy rewrite with Elder Fleet Liberation campaign, 3 game modes, procedural audio, WASM web builds.
-
-![EVE Rebellion Stack](https://img.shields.io/badge/Stack-Rust%20|%20Bevy%20|%20WASM-red)
-
-**Demonstrates:** Game development, Rust/ECS architecture, cross-platform builds
+| | |
+|---|---|
+| **Tests across active repos** | 17,000+ |
+| **Projects with CI green** | 10 |
+| **Shipped releases** | Argus Overview (2,500+ downloads), EVE Rebellion (WASM live) |
 
 ---
 
-## EVE Online Tools
+## Also Built
 
-| Project | Description |
-|---------|-------------|
-| [EVE Gatekeeper](https://github.com/AreteDriver/EVE_Gatekeeper) | Fleet intel, route planning, jump bridge networks — backend + mobile + desktop |
-| [Argus Overview](https://github.com/AreteDriver/Argus_Overview) | Multi-boxing tool for Linux with window previews |
-| [EVE Sentinel](https://github.com/AreteDriver/EVE_Sentinel) | Alliance intel and recruitment risk scoring |
-| [EVE Quartermaster](https://github.com/AreteDriver/EVE_Quartermaster) | Mobile companion — assets, routes, market |
-
----
-
-## Linux DevTools
-
-| Project | Description |
-|---------|-------------|
-| [LikX](https://github.com/AreteDriver/LikX) | Screenshot capture — X11/Wayland, OCR, annotations, cloud upload |
-| [G13 Linux](https://github.com/AreteDriver/G13_Linux) | Logitech G13 driver with macros, RGB, LCD display |
-| [RazerControls](https://github.com/AreteDriver/RazerControls) | Razer peripherals control center for Linux |
-| [SteamProtonHelper](https://github.com/AreteDriver/SteamProtonHelper) | Proton/Wine repair utility with CLI + GUI |
+| Project | What | Tests |
+|---------|------|------:|
+| [Dossier](https://github.com/AreteDriver/Dossier) | Document intelligence — NER, classification, OCR, forensics | 385 |
+| [Argus Overview](https://github.com/AreteDriver/Argus_Overview) | EVE Online multi-boxing tool for Linux | 1,875 |
+| [G13 Linux](https://github.com/AreteDriver/G13_Linux) | Logitech G13 driver — macros, RGB, LCD | 1,209 |
+| [ai-skills](https://github.com/AreteDriver/ai-skills) | 54 production skills for Claude Code agents | — |
+| [EVE Rebellion](https://github.com/AreteDriver/eve_rebellion_rust) | Arcade shooter — Rust/Bevy, 4 campaigns, WASM | 163 |
+| [EVE Gatekeeper](https://github.com/AreteDriver/EVE_Gatekeeper) | Fleet intel + route planning — backend, mobile, desktop | 2,099 |
 
 ---
 
 ## Technical Profile
 
-| Domain | Technologies |
-|--------|--------------|
-| **Languages** | Python, Rust, TypeScript, Swift |
-| **AI/ML** | Claude API, OpenAI, LangChain, prompt engineering |
-| **Backend** | FastAPI, Flask, Firebase, PostgreSQL, SQLite |
-| **Frontend** | React, Next.js, Streamlit, PySide6/Qt |
-| **DevOps** | Docker, GitHub Actions, Linux administration |
-| **Specialty** | Operational systems, multi-persona design, offline-first architecture |
-
----
-
-## AI Operating Model
-
-Every AI system I build follows these principles:
-
-| Layer | Implementation |
-|-------|----------------|
-| **Structured Outputs** | JSON schemas, Pydantic validation, typed responses |
-| **Safety Rails** | Input sanitization, content filtering, rate limiting |
-| **Retry/Fallback** | Exponential backoff, graceful degradation, circuit breakers |
-| **Telemetry** | Token usage, latency tracking, cost monitoring |
+**Languages:** Python, Rust, TypeScript, Swift
+**AI:** Claude API, OpenAI, multi-agent orchestration, prompt engineering
+**Infrastructure:** FastAPI, SQLite, PostgreSQL, Docker, GitHub Actions, Linux
+**Specialty:** Production AI systems — budget controls, agent coordination, resilience patterns
 
 ---
 
 ## Background
 
-- **17 years** in manufacturing operations (Toyota)
-- **Current:** AI Enablement & Workflow Analyst — converting ad-hoc AI experiments into documented, repeatable workflows
-- **Focus:** Forward Deployed Software Engineering, Solutions Engineering, AI Enablement
+- **17 years** manufacturing operations (Toyota Production System)
+- **Self-taught** software engineer
+- **Focus:** The boring infrastructure that makes AI actually work in production
 
 ---
 
 ## Connect
 
-- **Location**: Portland, OR
-- **Email**: jamesyng79@gmail.com
-- **LinkedIn**: [linkedin.com/in/james-young-3b77b3120](https://linkedin.com/in/james-young-3b77b3120)
+Portland, OR · [LinkedIn](https://linkedin.com/in/james-young-3b77b3120) · jamesyng79@gmail.com
 
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow?style=flat&logo=buy-me-a-coffee)](https://buymeacoffee.com/aretedriver)
-
----
-
-## GitHub Stats
-
-<p align="center">
-  <img src="https://github-readme-stats.vercel.app/api?username=AreteDriver&show_icons=true&theme=dark&hide_border=true" alt="GitHub Stats" />
-</p>
-
----
-
-> *I build systems that give operators the visibility they need to make better decisions faster.*


### PR DESCRIPTION
## Summary
- Reframe from "Forward Deployed Software Engineer" to "AI Infrastructure Builder"
- Pin Gorgon (orchestration), Convergent (coordination), RedOPS (security) — coherent story
- Outcomes over features: test counts, CI status, shipped releases
- Now/Proof sections replace generic "AI Operating Model" filler
- Updated all test counts to current (17,000+ total across repos)
- De-emphasized game/EVE projects into "Also Built" table
- Cut from 131 to 76 lines — scannable in 10 seconds

## Test plan
- [ ] Visual review on GitHub profile page
- [ ] Verify all repo links resolve
- [ ] Verify badge renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)